### PR TITLE
Throw an error if the user doesn't redact anything

### DIFF
--- a/veil-macros/src/fmt.rs
+++ b/veil-macros/src/fmt.rs
@@ -1,4 +1,4 @@
-use crate::flags::FieldFlags;
+use crate::{flags::FieldFlags, UnusedDiagnostic};
 use quote::ToTokens;
 use syn::spanned::Spanned;
 
@@ -25,7 +25,7 @@ fn is_ty_option(ty: &syn::Type) -> bool {
     }
 }
 
-pub enum FormatData<'a> {
+pub(crate) enum FormatData<'a> {
     /// Structs, struct enum variants
     FieldsNamed(&'a syn::FieldsNamed),
 
@@ -38,11 +38,12 @@ impl FormatData<'_> {
     /// `all_field_flags`: `FieldFlags` that apply to all fields, if set
     ///
     /// `with_self`: prepends `self.` to the field name for accessing struct fields
-    pub fn impl_debug(
+    pub(crate) fn impl_debug(
         self,
         name: proc_macro2::TokenStream,
         all_fields_flags: Option<FieldFlags>,
         with_self: bool,
+        unused: &mut UnusedDiagnostic,
     ) -> Result<proc_macro2::TokenStream, syn::Error> {
         let fields = match self {
             Self::FieldsNamed(syn::FieldsNamed { named: fields, .. })
@@ -102,7 +103,7 @@ impl FormatData<'_> {
                 // Specialization for Option<T>
                 let is_option = is_ty_option(&field.ty);
 
-                field_bodies.push(generate_redact_call(field_accessor, is_option, &field_flags));
+                field_bodies.push(generate_redact_call(field_accessor, is_option, &field_flags, unused));
             } else {
                 // Otherwise, just use the normal `Debug` implementation.
                 field_bodies.push(quote! { #field_accessor });
@@ -145,12 +146,16 @@ impl FormatData<'_> {
 }
 
 /// Generates a call to `veil::private::redact`
-pub fn generate_redact_call(
+pub(crate) fn generate_redact_call(
     field_accessor: proc_macro2::TokenStream,
     is_option: bool,
     field_flags: &FieldFlags,
+    unused: &mut UnusedDiagnostic,
 ) -> proc_macro2::TokenStream {
     if !field_flags.skip {
+        // This is the one place where we actually track whether the derive macro had any effect! Nice.
+        unused.redacted_something();
+
         // Environment awareness (we assume that we injected the `__veil_env_is_redaction_enabled` function earlier)
         let env_is_redaction_enabled = if cfg!(feature = "environment-aware") {
             quote! {

--- a/veil-macros/src/lib.rs
+++ b/veil-macros/src/lib.rs
@@ -9,6 +9,34 @@ mod flags;
 mod fmt;
 mod structs;
 
+/// Keep track of whether we actually redact anything.
+///
+/// By default fields are not redacted. One must add #[redact(...)] to them.
+///
+/// We should throw an error if no fields are redacted, because the user should derive Debug instead.
+///
+/// This should also be aware of #[redact(skip)] - we shouldn't let users bypass this check via that.
+struct UnusedDiagnostic(bool);
+impl UnusedDiagnostic {
+    #[inline(always)]
+    /// We redacted something! Don't throw an error saying the derive was unused.
+    pub(crate) fn redacted_something(&mut self) {
+        self.0 = false;
+    }
+
+    #[inline(always)]
+    #[must_use]
+    fn should_throw_err(self) -> bool {
+        self.0
+    }
+}
+impl Default for UnusedDiagnostic {
+    #[inline(always)]
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
 #[proc_macro_derive(Redact, attributes(redact))]
 /// Implements [`std::fmt::Debug`] for a struct or enum variant, with certain fields redacted.
 ///
@@ -16,11 +44,27 @@ mod structs;
 pub fn derive_redact(item: TokenStream) -> TokenStream {
     let item = syn::parse_macro_input!(item as syn::DeriveInput);
 
+    // Unfortunately this is somewhat complex to implement at this stage of the macro "pipeline",
+    // so we'll pass around a mutable reference to this variable, and set it to false if we redact anything.
+    // TBH this kind of smells, but I can't think of a better way to do it.
+    let mut unused = UnusedDiagnostic::default();
+
+    let item_span = item.span();
+
     let result = match item.data {
-        syn::Data::Struct(s) => structs::derive_redact(s, item.attrs, item.ident),
-        syn::Data::Enum(e) => enums::derive_redact(e, item.attrs, item.ident),
-        syn::Data::Union(_) => Err(syn::Error::new(item.span(), "this trait cannot be derived for unions")),
+        syn::Data::Struct(s) => structs::derive_redact(s, item.attrs, item.ident, &mut unused),
+        syn::Data::Enum(e) => enums::derive_redact(e, item.attrs, item.ident, &mut unused),
+        syn::Data::Union(_) => Err(syn::Error::new(item_span, "this trait cannot be derived for unions")),
     };
+
+    if unused.should_throw_err() {
+        return syn::Error::new(
+            item_span,
+            "`#[derive(Redact)]` does nothing by default, you must specify at least one field to redact. You should `#[derive(Debug)]` instead if this is intentional",
+        )
+        .into_compile_error()
+        .into();
+    }
 
     match result {
         Ok(tokens) => tokens,

--- a/veil-macros/src/structs.rs
+++ b/veil-macros/src/structs.rs
@@ -1,12 +1,13 @@
-use crate::{flags::FieldFlags, fmt::FormatData};
+use crate::{flags::FieldFlags, fmt::FormatData, UnusedDiagnostic};
 use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::spanned::Spanned;
 
-pub fn derive_redact(
+pub(super) fn derive_redact(
     s: syn::DataStruct,
     attrs: Vec<syn::Attribute>,
     name_ident: syn::Ident,
+    unused: &mut UnusedDiagnostic,
 ) -> Result<TokenStream, syn::Error> {
     // Parse #[redact(all, variant, ...)] from the enum attributes, if present.
     let top_level_flags = match attrs.len() {
@@ -43,10 +44,10 @@ pub fn derive_redact(
     // Generate the body of the std::fmt::Debug implementation
     let impl_debug = match &s.fields {
         syn::Fields::Named(named) => {
-            FormatData::FieldsNamed(named).impl_debug(name_ident_str, top_level_flags, true)?
+            FormatData::FieldsNamed(named).impl_debug(name_ident_str, top_level_flags, true, unused)?
         }
         syn::Fields::Unnamed(unnamed) => {
-            FormatData::FieldsUnnamed(unnamed).impl_debug(name_ident_str, top_level_flags, true)?
+            FormatData::FieldsUnnamed(unnamed).impl_debug(name_ident_str, top_level_flags, true, unused)?
         }
         syn::Fields::Unit => {
             return Err(syn::Error::new(


### PR DESCRIPTION
#[derive(Redact)] would be redundant in that case and they should #[derive(Debug)] instead