### PR TITLE
Do not break on external attributes usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ name = "veil-tests"
 version = "0.0.0"
 dependencies = [
  "regex",
+ "serde",
  "trybuild",
  "veil",
  "walkdir",

--- a/veil-macros/src/flags.rs
+++ b/veil-macros/src/flags.rs
@@ -45,14 +45,14 @@ impl FieldFlags {
         let mut head = 0;
 
         for attr in attrs {
-            if head == AMOUNT {
-                return Err(syn::Error::new(
-                    attr.span(),
-                    "too many `#[redact(...)]` attributes specified",
-                ));
-            }
-
             if let Some(flags) = Self::parse(attr)? {
+                if head == AMOUNT {
+                    return Err(syn::Error::new(
+                        attr.span(),
+                        "too many `#[redact(...)]` attributes specified",
+                    ));
+                }
+
                 if flags.skip {
                     if !skip_allowed {
                         return Err(syn::Error::new(attr.span(), "`#[redact(skip)]` is not allowed here"));

--- a/veil-macros/src/fmt.rs
+++ b/veil-macros/src/fmt.rs
@@ -74,7 +74,7 @@ impl FormatData<'_> {
             // Parse field flags from attributes on this field
             let field_flags = match field.attrs.len() {
                 0 => all_fields_flags,
-                1 => match FieldFlags::extract::<1>(&field.attrs, all_fields_flags.is_some())? {
+                _ => match FieldFlags::extract::<1>(&field.attrs, all_fields_flags.is_some())? {
                     [Some(flags)] => {
                         if flags.variant {
                             return Err(syn::Error::new(
@@ -93,12 +93,6 @@ impl FormatData<'_> {
 
                     [None] => None,
                 },
-                _ => {
-                    return Err(syn::Error::new(
-                        field.span(),
-                        "only one `#[redact(...)]` attribute is allowed per field",
-                    ))
-                }
             };
 
             // If we have field flags...

--- a/veil-tests/Cargo.toml
+++ b/veil-tests/Cargo.toml
@@ -11,3 +11,4 @@ veil = { path = "../" }
 trybuild = "1"
 regex = "1"
 walkdir = "2"
+serde = { version = "1", features = ["derive"] }

--- a/veil-tests/src/compile_tests.rs
+++ b/veil-tests/src/compile_tests.rs
@@ -173,3 +173,14 @@ fn test_redact_all_with_flags() {
 fn test_redact_tuple_struct() {
     println!("{:#?}", TupleStruct(100, 2000000));
 }
+
+#[test]
+fn test_redact_multiple_attributes() {
+    #[derive(serde::Serialize, Redact)]
+    struct MultipleAttributes {
+        #[redact]
+        #[serde(default)]
+        hidden: bool,
+        exposed: bool,
+    }
+}

--- a/veil-tests/src/compile_tests/fail/redact_too_many.stderr
+++ b/veil-tests/src/compile_tests/fail/redact_too_many.stderr
@@ -1,7 +1,7 @@
-error: only one `#[redact(...)]` attribute is allowed per field
- --> src/compile_tests/fail/redact_too_many.rs:5:5
+error: too many `#[redact(...)]` attributes specified
+ --> src/compile_tests/fail/redact_too_many.rs:6:5
   |
-5 |     #[redact]
+6 |     #[redact]
   |     ^
 
 error: a `#[redact(variant, ...)]` is already present


### PR DESCRIPTION
We noticed that using external attributes (ex: `serde`) was breaking the macro. In this fix we allow the use of other attributes other than `redact`.