### PR TITLE
[PLATFORM-831]: Fix generics syntax in derive macro

### DIFF
--- a/veil-macros/src/enums.rs
+++ b/veil-macros/src/enums.rs
@@ -15,6 +15,7 @@ struct EnumVariantFieldFlags {
 
 pub(super) fn derive_redact(
     e: syn::DataEnum,
+    generics: syn::Generics,
     attrs: Vec<syn::Attribute>,
     name_ident: syn::Ident,
     unused: &mut UnusedDiagnostic,
@@ -178,8 +179,9 @@ pub(super) fn derive_redact(
         });
     }
 
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     Ok(quote! {
-        impl ::std::fmt::Debug for #name_ident {
+        impl #impl_generics ::std::fmt::Debug for #name_ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 let debug_alternate = f.alternate();
                 match self {

--- a/veil-macros/src/lib.rs
+++ b/veil-macros/src/lib.rs
@@ -58,8 +58,8 @@ pub fn derive_redact(item: TokenStream) -> TokenStream {
     let item_span = item.span();
 
     let result = match item.data {
-        syn::Data::Struct(s) => structs::derive_redact(s, item.attrs, item.ident, &mut unused),
-        syn::Data::Enum(e) => enums::derive_redact(e, item.attrs, item.ident, &mut unused),
+        syn::Data::Struct(s) => structs::derive_redact(s, item.generics, item.attrs, item.ident, &mut unused),
+        syn::Data::Enum(e) => enums::derive_redact(e, item.generics, item.attrs, item.ident, &mut unused),
         syn::Data::Union(_) => Err(syn::Error::new(item_span, "this trait cannot be derived for unions")),
     };
 

--- a/veil-macros/src/structs.rs
+++ b/veil-macros/src/structs.rs
@@ -5,6 +5,7 @@ use syn::spanned::Spanned;
 
 pub(super) fn derive_redact(
     s: syn::DataStruct,
+    generics: syn::Generics,
     attrs: Vec<syn::Attribute>,
     name_ident: syn::Ident,
     unused: &mut UnusedDiagnostic,
@@ -57,8 +58,9 @@ pub(super) fn derive_redact(
         }
     };
 
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     Ok(quote! {
-        impl ::std::fmt::Debug for #name_ident {
+        impl #impl_generics ::std::fmt::Debug for #name_ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 let debug_alternate = f.alternate();
                 #impl_debug;

--- a/veil-tests/src/compile_tests.rs
+++ b/veil-tests/src/compile_tests.rs
@@ -98,6 +98,31 @@ enum Country {
 #[derive(Redact)]
 struct TupleStruct(#[redact] u32, #[redact(partial)] u32);
 
+#[derive(Redact)]
+struct GenericStruct<Foo: std::fmt::Debug, Bar: std::fmt::Debug>(Foo, #[redact] Bar);
+
+#[derive(Redact)]
+struct GenericWhereStruct<Foo, Bar>(Foo, #[redact] Bar)
+where
+    Foo: std::fmt::Debug,
+    Bar: std::fmt::Debug;
+
+#[derive(Redact)]
+enum GenericWhereEnum<Foo, Bar>
+where
+    Foo: std::fmt::Debug,
+    Bar: std::fmt::Debug,
+{
+    FooVariant(Foo),
+    BarVariant(#[redact] Bar),
+}
+
+#[derive(Redact)]
+enum GenericEnum<Foo: std::fmt::Debug, Bar: std::fmt::Debug> {
+    FooVariant(Foo),
+    BarVariant(#[redact] Bar),
+}
+
 #[test]
 fn test_credit_card_redacting() {
     println!(


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-831

This fixes the bug where generic bounds syntax doesn't compile when deriving `Redact` for structs and enums.
