### PR TITLE
[PLATFORM-833]: Add a way of using the Display implementation instead of the Debug implementation when redacting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //! | `#[redact(partial)]`           |   | If the string is long enough, a small part of the<br>beginning and end will be exposed. If the string is too short to securely expose a portion of it, it will be redacted entirely. |   | Disabled. The entire string will be redacted. |
 //! | `#[redact(with = 'X')]`        |   | Specifies the `char` the string will be redacted with.                                                                                                                               |   | `'*'`                                         |
 //! | `#[redact(fixed = <integer>)]` |   | If this modifier is present, the length and contents of<br>the string are completely ignored and the string will always<br>be redacted as a fixed number of redaction characters.    |   | Disabled.                                     |
+//! | `#[redact(display)]`           |   | Overrides the redaction behavior to use the type's [`std::fmt::Display`] implementation instead of [`std::fmt::Debug`].                                                              |   | Disabled.                                     |
 //!
 //! # Redacting All Fields in a Struct or Enum Variant
 //!

--- a/veil-macros/src/enums.rs
+++ b/veil-macros/src/enums.rs
@@ -61,7 +61,7 @@ pub(super) fn derive_redact(
                     if flags.display {
                         return Err(syn::Error::new(
                             variant.attrs[0].span(),
-                            "`#[redact(display)]` is invalid here",
+                            "`#[redact(display)]` is invalid here, enum variants are always displayed using std::fmt::Display",
                         ));
                     }
 
@@ -73,7 +73,7 @@ pub(super) fn derive_redact(
                 } else {
                     return Err(syn::Error::new(
                         variant.span(),
-                        "expected `#[redact(all, ...)]` or `#[redact(variant, ...)]`, or both as separate attributes",
+                        "please specify at least `#[redact(all, ...)]` or `#[redact(variant, ...)]` first, or both as separate attributes",
                     ));
                 }
             }
@@ -109,7 +109,7 @@ pub(super) fn derive_redact(
                     } else {
                         return Err(syn::Error::new(
                             variant.span(),
-                            "expected `#[redact(all, ...)]` or `#[redact(variant, ...)]`, or both as separate attributes",
+                            "please specify at least `#[redact(all, ...)]` or `#[redact(variant, ...)]` first, or both as separate attributes",
                         ));
                     }
                 }

--- a/veil-macros/src/enums.rs
+++ b/veil-macros/src/enums.rs
@@ -29,10 +29,7 @@ pub(super) fn derive_redact(
                     "at least `#[redact(all, variant)]` is required here to redact all variant names",
                 ));
             } else if flags.display {
-                return Err(syn::Error::new(
-                    attrs[0].span(),
-                    "`#[redact(display)]` is invalid here",
-                ));
+                return Err(syn::Error::new(attrs[0].span(), "`#[redact(display)]` is invalid here"));
             } else {
                 Some(flags)
             }

--- a/veil-macros/src/enums.rs
+++ b/veil-macros/src/enums.rs
@@ -183,10 +183,13 @@ pub(super) fn derive_redact(
     Ok(quote! {
         impl #impl_generics ::std::fmt::Debug for #name_ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                let debug_alternate = f.alternate();
+                #[allow(unused)] // Suppresses unused warning with `#[redact(display)]`
+                let alternate = f.alternate();
+
                 match self {
                     #(Self::#variant_idents #variant_destructures => { #variant_bodies; },)*
                 }
+
                 Ok(())
             }
         }

--- a/veil-macros/src/enums.rs
+++ b/veil-macros/src/enums.rs
@@ -28,6 +28,11 @@ pub(super) fn derive_redact(
                     attrs[0].span(),
                     "at least `#[redact(all, variant)]` is required here to redact all variant names",
                 ));
+            } else if flags.display {
+                return Err(syn::Error::new(
+                    attrs[0].span(),
+                    "`#[redact(display)]` is invalid here",
+                ));
             } else {
                 Some(flags)
             }
@@ -56,6 +61,13 @@ pub(super) fn derive_redact(
                         all_fields_flags: Some(flags),
                     }
                 } else if flags.variant {
+                    if flags.display {
+                        return Err(syn::Error::new(
+                            variant.attrs[0].span(),
+                            "`#[redact(display)]` is invalid here",
+                        ));
+                    }
+
                     // #[redact(variant, ...)]
                     EnumVariantFieldFlags {
                         variant_flags: Some(flags),

--- a/veil-macros/src/flags.rs
+++ b/veil-macros/src/flags.rs
@@ -28,6 +28,9 @@ pub struct FieldFlags {
     ///
     /// Fields are not redacted by default unless their parent is marked as `#[redact(all)]`, and this flag turns off that redaction for this specific field.
     pub skip: bool,
+
+    /// Whether to use the type's [`std::fmt::Display`] implementation instead of [`std::fmt::Debug`].
+    pub display: bool,
 }
 impl FieldFlags {
     /// Returns a list of `FieldFlags` parsed from an attribute.
@@ -121,6 +124,11 @@ impl FieldFlags {
                     flags.variant = true;
                 }
 
+                // #[redact(display)]
+                syn::Meta::Path(path) if path.is_ident("display") => {
+                    flags.display = true;
+                }
+
                 // #[redact(with = 'X')]
                 syn::Meta::NameValue(kv) if kv.path.is_ident("with") => match kv.lit {
                     syn::Lit::Char(with) => flags.redact_char = with.value(),
@@ -164,6 +172,7 @@ impl Default for FieldFlags {
             variant: false,
             all: false,
             skip: false,
+            display: false,
         }
     }
 }

--- a/veil-macros/src/fmt.rs
+++ b/veil-macros/src/fmt.rs
@@ -152,12 +152,28 @@ pub(crate) fn generate_redact_call(
         // This is the one place where we actually track whether the derive macro had any effect! Nice.
         unused.redacted_something();
 
-        quote! {
-            ::veil::private::redact(#field_accessor, ::veil::private::RedactFlags {
-                debug_alternate,
-                is_option: #is_option,
-                #field_flags
-            })
+        if field_flags.display {
+            // std::fmt::Display
+            quote! {
+                ::veil::private::redact(
+                    ::veil::private::RedactionTarget::Display(#field_accessor),
+                    ::veil::private::RedactFlags {
+                        is_option: #is_option,
+                        #field_flags
+                    }
+                )
+            }
+        } else {
+            // std::fmt::Debug
+            quote! {
+                ::veil::private::redact(
+                    ::veil::private::RedactionTarget::Debug { this: #field_accessor, alternate },
+                    ::veil::private::RedactFlags {
+                        is_option: #is_option,
+                        #field_flags
+                    }
+                )
+            }
         }
     } else {
         field_accessor

--- a/veil-macros/src/structs.rs
+++ b/veil-macros/src/structs.rs
@@ -62,8 +62,11 @@ pub(super) fn derive_redact(
     Ok(quote! {
         impl #impl_generics ::std::fmt::Debug for #name_ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                let debug_alternate = f.alternate();
+                #[allow(unused)] // Suppresses unused warning with `#[redact(display)]`
+                let alternate = f.alternate();
+
                 #impl_debug;
+
                 Ok(())
             }
         }

--- a/veil-tests/src/compile_tests/fail.rs
+++ b/veil-tests/src/compile_tests/fail.rs
@@ -18,5 +18,6 @@ fail_tests! {
     redact_union,
     redact_units,
     redact_skip,
-    redact_missing_all
+    redact_missing_all,
+    redact_display_enum_variant
 }

--- a/veil-tests/src/compile_tests/fail/redact_display_enum_variant.rs
+++ b/veil-tests/src/compile_tests/fail/redact_display_enum_variant.rs
@@ -1,0 +1,19 @@
+fn main() {}
+
+#[derive(veil::Redact)]
+pub enum Foo {
+    #[redact(variant, display)]
+    Bar,
+}
+
+#[derive(veil::Redact)]
+pub enum Bar {
+    #[redact(display)]
+    Baz,
+}
+
+#[derive(veil::Redact)]
+#[redact(all, variant, display)]
+pub enum Baz {
+    Qux,
+}

--- a/veil-tests/src/compile_tests/fail/redact_display_enum_variant.stderr
+++ b/veil-tests/src/compile_tests/fail/redact_display_enum_variant.stderr
@@ -4,7 +4,7 @@ error: `#[redact(display)]` is invalid here
 5 |     #[redact(variant, display)]
   |     ^
 
-error: expected `#[redact(all, ...)]` or `#[redact(variant, ...)]`, or both as separate attributes
+error: please specify at least `#[redact(all, ...)]` or `#[redact(variant, ...)]` first, or both as separate attributes
   --> src/compile_tests/fail/redact_display_enum_variant.rs:11:5
    |
 11 |     #[redact(display)]

--- a/veil-tests/src/compile_tests/fail/redact_display_enum_variant.stderr
+++ b/veil-tests/src/compile_tests/fail/redact_display_enum_variant.stderr
@@ -1,4 +1,4 @@
-error: `#[redact(display)]` is invalid here
+error: `#[redact(display)]` is invalid here, enum variants are always displayed using std::fmt::Display
  --> src/compile_tests/fail/redact_display_enum_variant.rs:5:5
   |
 5 |     #[redact(variant, display)]

--- a/veil-tests/src/compile_tests/fail/redact_display_enum_variant.stderr
+++ b/veil-tests/src/compile_tests/fail/redact_display_enum_variant.stderr
@@ -1,0 +1,17 @@
+error: `#[redact(display)]` is invalid here
+ --> src/compile_tests/fail/redact_display_enum_variant.rs:5:5
+  |
+5 |     #[redact(variant, display)]
+  |     ^
+
+error: expected `#[redact(all, ...)]` or `#[redact(variant, ...)]`, or both as separate attributes
+  --> src/compile_tests/fail/redact_display_enum_variant.rs:11:5
+   |
+11 |     #[redact(display)]
+   |     ^
+
+error: `#[redact(display)]` is invalid here
+  --> src/compile_tests/fail/redact_display_enum_variant.rs:16:1
+   |
+16 | #[redact(all, variant, display)]
+   | ^

--- a/veil-tests/src/compile_tests/fail/redact_enum_without_variant.stderr
+++ b/veil-tests/src/compile_tests/fail/redact_enum_without_variant.stderr
@@ -4,7 +4,7 @@ error: at least `#[redact(all, variant)]` is required here to redact all variant
 4 | #[redact(all)]
   | ^
 
-error: expected `#[redact(all, ...)]` or `#[redact(variant, ...)]`, or both as separate attributes
+error: please specify at least `#[redact(all, ...)]` or `#[redact(variant, ...)]` first, or both as separate attributes
   --> src/compile_tests/fail/redact_enum_without_variant.rs:11:5
    |
 11 |     #[redact]

--- a/veil-tests/src/compile_tests/succeed.rs
+++ b/veil-tests/src/compile_tests/succeed.rs
@@ -62,6 +62,25 @@ struct RedactAllWithFlags {
 }
 
 #[derive(Redact)]
+#[redact(all, partial, with = 'X', display)]
+struct RedactAllWithFlagsDisplay {
+    field: String,
+
+    #[redact(skip)]
+    field2: String,
+
+    field3: String,
+}
+
+#[derive(Redact)]
+struct RedactNamedDisplay {
+    #[redact(display)]
+    field: String,
+    #[redact]
+    field2: String,
+}
+
+#[derive(Redact)]
 enum CreditCardIssuer {
     #[redact(variant)]
     Visa {
@@ -76,7 +95,7 @@ enum CreditCardIssuer {
     MasterCard,
 
     #[redact(variant)]
-    #[redact(all, fixed = 6, with = '$')]
+    #[redact(all, fixed = 6, with = '$', display)]
     SecretAgentCard {
         secret_data_1: String,
         secret_data_2: String,

--- a/veil-tests/src/redaction_tests.rs
+++ b/veil-tests/src/redaction_tests.rs
@@ -12,6 +12,8 @@ pub const SENSITIVE_DATA: &[&str] = &[
     "SensitiveVariant",
 ];
 
+const DEBUGGY_PHRASE: &str = "Hello \"William\"!\nAnd here's the newline...";
+
 pub fn assert_has_sensitive_data<T: std::fmt::Debug>(data: T) {
     for redacted in [format!("{data:?}"), format!("{data:#?}")] {
         assert!(
@@ -158,4 +160,38 @@ fn test_display_redaction() {
 
     assert_eq!(format!("{:?}", RedactDebug("\"".to_string())), r#"RedactDebug("\"")"#);
     assert_eq!(format!("{:?}", RedactDisplay("\"".to_string())), r#"RedactDisplay(")"#);
+}
+
+#[test]
+fn test_named_display_redaction() {
+    #[derive(Redact)]
+    struct RedactMultipleNamedDisplay {
+        #[redact(display)]
+        foo: String,
+        #[redact]
+        bar: String
+    }
+
+    assert_eq!(
+        format!("{:?}", RedactMultipleNamedDisplay { foo: DEBUGGY_PHRASE.to_string(), bar: DEBUGGY_PHRASE.to_string() }),
+        "RedactMultipleNamedDisplay { foo: ***** \"*******\"!\n*** ****'* *** *******..., bar: \"***** \\\"*******\\\"!\\**** ****'* *** *******...\" }"
+    );
+}
+
+#[test]
+fn test_enum_display_redaction() {
+    #[derive(Redact)]
+    enum RedactEnum {
+        Foo {
+            #[redact(display)]
+            foo: String,
+            #[redact]
+            bar: String
+        }
+    }
+
+    assert_eq!(
+        format!("{:?}", RedactEnum::Foo { foo: DEBUGGY_PHRASE.to_string(), bar: DEBUGGY_PHRASE.to_string() }),
+        "Foo { foo: ***** \"*******\"!\n*** ****'* *** *******..., bar: \"***** \\\"*******\\\"!\\**** ****'* *** *******...\" }"
+    );
 }

--- a/veil-tests/src/redaction_tests.rs
+++ b/veil-tests/src/redaction_tests.rs
@@ -169,7 +169,7 @@ fn test_named_display_redaction() {
         #[redact(display)]
         foo: String,
         #[redact]
-        bar: String
+        bar: String,
     }
 
     assert_eq!(
@@ -186,8 +186,8 @@ fn test_enum_display_redaction() {
             #[redact(display)]
             foo: String,
             #[redact]
-            bar: String
-        }
+            bar: String,
+        },
     }
 
     assert_eq!(

--- a/veil-tests/src/redaction_tests.rs
+++ b/veil-tests/src/redaction_tests.rs
@@ -147,3 +147,15 @@ fn test_sensitive_tuple_structs() {
         SENSITIVE_DATA[3],
     ));
 }
+
+#[test]
+fn test_display_redaction() {
+    #[derive(Redact)]
+    struct RedactDisplay(#[redact(display)] String);
+
+    #[derive(Redact)]
+    struct RedactDebug(#[redact] String);
+
+    assert_eq!(format!("{:?}", RedactDebug("\"".to_string())), r#"RedactDebug("\"")"#);
+    assert_eq!(format!("{:?}", RedactDisplay("\"".to_string())), r#"RedactDisplay(")"#);
+}


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-833

This PR implements the `#[redact(display)]` option which allows the user to override which format implementation is chosen to redact.

This allows users to choose redacting the output of a type's `std::fmt::Display` implementation where they feel is appropriate.

Relevant Slack discussion https://prima.slack.com/archives/C01C70U9F37/p1670860264520579
