### PR TITLE
[PLATFORM-837]: Manual redaction of data

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,112 @@
+use crate::private::{redact_from_builder, RedactFlags};
+
+/// The `Redactor` allows for redacting arbitrary strings using a pre-defined set of flags.
+///
+/// To build a `Redactor`, use the [`RedactorBuilder`].
+pub struct Redactor(RedactFlags);
+impl Redactor {
+    /// Redact the given string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use veil::RedactorBuilder;
+    /// let email = "john.doe@prima.it".to_string();
+    /// let name = "John Doe".to_string();
+    ///
+    /// let redactor = RedactorBuilder::new().char('X').partial().build().unwrap();
+    ///
+    /// let email = redactor.redact(email);
+    /// let name = redactor.redact(name);
+    ///
+    /// assert_eq!(
+    ///     format!("{} <{}>", name, email),
+    ///     "JoXX Xoe <johX.XXX@XXXXa.it>"
+    /// );
+    /// ```
+    pub fn redact(&self, data: String) -> String {
+        redact_from_builder(data, self.0, None)
+    }
+
+    /// Redact the given string in-place.
+    ///
+    /// Convenience method for chaining.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use veil::RedactorBuilder;
+    /// let mut email = "john.doe@prima.it".to_string();
+    /// let mut name = "John Doe".to_string();
+    ///
+    /// RedactorBuilder::new()
+    ///     .char('X')
+    ///     .partial()
+    ///     .build()
+    ///     .unwrap()
+    ///     .and_redact(&mut email)
+    ///     .and_redact(&mut name);
+    ///
+    /// assert_eq!(
+    ///     format!("{} <{}>", name, email),
+    ///     "JoXX Xoe <johX.XXX@XXXXa.it>"
+    /// );
+    /// ```
+    pub fn and_redact(&self, data: &mut String) -> &Self {
+        *data = self.redact(core::mem::take(data));
+        self
+    }
+}
+
+/// A checked builder for [`Redactor`]s.
+pub struct RedactorBuilder {
+    redact_char: Option<char>,
+    partial: bool,
+}
+impl RedactorBuilder {
+    /// Initialize a new redaction flag builder.
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self {
+            redact_char: None,
+            partial: false,
+        }
+    }
+
+    /// Set the character to use for redacting.
+    ///
+    /// Equivalent to `#[redact(with = '...')]` when deriving.
+    #[inline(always)]
+    pub const fn char(mut self, char: char) -> Self {
+        self.redact_char = Some(char);
+        self
+    }
+
+    /// Whether to only partially redact the data.
+    ///
+    /// Equivalent to `#[redact(partial)]` when deriving.
+    #[inline(always)]
+    pub const fn partial(mut self) -> Self {
+        self.partial = true;
+        self
+    }
+
+    /// Build the redaction flags.
+    ///
+    /// Returns an error if the state of the builder is invalid.
+    /// The error will be optimised away by the compiler if the builder is valid at compile time, so it's safe and zero-cost to use `unwrap` on the result if you are constructing this at compile time.
+    #[inline(always)]
+    pub const fn build(self) -> Result<Redactor, &'static str> {
+        let mut flags = RedactFlags {
+            partial: self.partial,
+            redact_char: '*',
+            fixed: 0,
+        };
+
+        if let Some(char) = self.redact_char {
+            flags.redact_char = char;
+        }
+
+        Ok(Redactor(flags))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ mod pii;
 pub use pii::RedactPii;
 
 mod builder;
-pub use builder::{Redactor, RedactorBuilder};
+pub use builder::{Redactor, RedactorBuilder, WrappedPii};
 
 #[cfg(feature = "toggle")]
 mod toggle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //! | `#[redact(partial)]`           |   | If the string is long enough, a small part of the<br>beginning and end will be exposed. If the string is too short to securely expose a portion of it, it will be redacted entirely. |   | Disabled. The entire string will be redacted. |
 //! | `#[redact(with = 'X')]`        |   | Specifies the `char` the string will be redacted with.                                                                                                                               |   | `'*'`                                         |
 //! | `#[redact(fixed = <integer>)]` |   | If this modifier is present, the length and contents of<br>the string are completely ignored and the string will always<br>be redacted as a fixed number of redaction characters.    |   | Disabled.                                     |
+//! | `#[redact(display)]`           |   | Overrides the redaction behavior to use the type's [`std::fmt::Display`] implementation instead of [`std::fmt::Debug`].                                                              |   | Disabled.                                     |
 //!
 //! # Redacting All Fields in a Struct or Enum Variant
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Implements [`std::fmt::Debug`] for a struct or enum variant, with certain fields redacted.
@@ -220,6 +221,14 @@
 //! [`std::fmt::Display`] should NOT be redacted. It is meant to be human-readable, and also has a snowball effect on [`ToString`]
 //! as [`std::fmt::Display`] automatically implements it, leading to confusing and unexpected behaviour.
 //!
+//! # Manually Redacting Data
+//!
+//! If you want to manually redact data, you have a few options:
+//!
+//! * Use the [`Pii`] derive macro to generate a [`RedactPii`] trait implementation for your type.
+//! * Implement the [`RedactPii`] trait manually.
+//! * Use the provided [`RedactorBuilder`] to build a [`Redactor`] instance.
+//!
 //! # Environmental Awareness
 //!
 //! In testing environments it may be useful to disable redaction entirely. You can globally disable Veil's redaction behavior at runtime by enabling the *non-default* feature flag `toggle` and:
@@ -230,9 +239,15 @@
 //!
 //! - Calling the [`veil::disable`](disable) function. See this [example](https://github.com/primait/veil/blob/master/examples/disable_redaction.rs).
 //!
-//! These are only checked ONCE for security purposes.
+//! These are only checked ONCE for security reasons.
 
-pub use veil_macros::Redact;
+pub use veil_macros::{Pii, Redact};
+
+mod pii;
+pub use pii::RedactPii;
+
+mod builder;
+pub use builder::{Redactor, RedactorBuilder};
 
 #[cfg(feature = "toggle")]
 mod toggle;

--- a/src/pii.rs
+++ b/src/pii.rs
@@ -1,0 +1,19 @@
+/// Types that are PII (Personally Identifiable Information) and can be redact-formatted.
+///
+/// The type must have an implementation of [`std::fmt::Display`] so that it can also be formatted in plain text without redaction.
+///
+/// This trait can be derived using the [`Pii`](crate::Pii) macro.
+pub trait RedactPii: std::fmt::Display {
+    /// Returns this value formatted as a string with all PII redacted.
+    fn redact(&self) -> String {
+        let mut buffer = String::new();
+
+        self.redact_into(&mut buffer)
+            .expect("writing to a String should never fail");
+
+        buffer
+    }
+
+    /// Writes this value formatted as a string with all PII redacted into the given buffer.
+    fn redact_into<W: std::fmt::Write>(&self, buffer: &mut W) -> std::fmt::Result;
+}

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display};
 
 #[repr(transparent)]
-pub struct DisplayDebug(String);
+pub struct DisplayDebug(pub String);
 impl std::fmt::Debug for DisplayDebug {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.0.as_str())
@@ -14,7 +14,7 @@ impl AsRef<str> for DisplayDebug {
     }
 }
 
-pub struct RedactFlags {
+pub enum RedactSpecialization {
     /// Whether the type we're redacting is an Option<T> or not. Poor man's specialization! This is detected
     /// by the proc macro reading the path to the type, so it's not perfect.
     ///
@@ -28,8 +28,11 @@ pub struct RedactFlags {
     ///
     /// * Once trait upcasting is stabilized, we could use it to upcast the dyn Debug pointer to a dyn Any and then
     /// downcast it to a concrete Option<T> and redact it directly.
-    pub is_option: bool,
+    Option,
+}
 
+#[derive(Clone, Copy)]
+pub struct RedactFlags {
     /// Whether to only partially redact the data.
     ///
     /// Incompatible with `fixed`.
@@ -96,11 +99,8 @@ impl RedactFlags {
         }
     }
 
-    fn redact_fixed(&self, width: usize, redacted: &mut String) {
-        redacted.reserve_exact(width);
-        for _ in 0..width {
-            redacted.push(self.redact_char);
-        }
+    fn redact_fixed(width: usize, char: char) -> String {
+        String::from_iter(std::iter::repeat_with(|| char).take(width))
     }
 }
 
@@ -117,35 +117,16 @@ pub enum RedactionTarget<'a> {
     Display(&'a dyn Display),
 }
 
-pub fn redact(this: RedactionTarget, flags: RedactFlags) -> DisplayDebug {
-    let mut redacted = String::new();
+fn redact_impl(redactable_string: String, flags: RedactFlags, specialization: Option<RedactSpecialization>) -> String {
+    let mut redacted = String::with_capacity(redactable_string.len());
 
-    let to_redactable_string = || match this {
-        RedactionTarget::Debug { this, alternate: false } => format!("{:?}", this),
-        RedactionTarget::Debug { this, alternate: true } => format!("{:#?}", this),
-        RedactionTarget::Display(this) => this.to_string(),
-    };
-
-    #[cfg(feature = "toggle")]
-    if crate::toggle::get_redaction_behavior().is_plaintext() {
-        return DisplayDebug(to_redactable_string());
-    }
-
-    (|| {
-        if flags.fixed > 0 {
-            flags.redact_fixed(flags.fixed as usize, &mut redacted);
-            return;
-        }
-
-        let redactable_string = to_redactable_string();
-
-        redacted.reserve(redactable_string.len());
-
-        // Specialize for Option<T>
-        if flags.is_option {
+    #[allow(clippy::single_match)]
+    match specialization {
+        Some(RedactSpecialization::Option) => {
             if redactable_string == "None" {
                 // We don't need to do any redacting
                 // https://prima.slack.com/archives/C03URH9N43U/p1661423554871499
+                return redactable_string;
             } else if let Some(inner) = redactable_string
                 .strip_prefix("Some(")
                 .and_then(|inner| inner.strip_suffix(')'))
@@ -157,15 +138,57 @@ pub fn redact(this: RedactionTarget, flags: RedactFlags) -> DisplayDebug {
                 // This should never happen, but just in case...
                 flags.redact_full(&redactable_string, &mut redacted);
             }
-            return;
+            return redacted;
         }
 
-        if flags.partial {
-            flags.redact_partial(&redactable_string, &mut redacted);
-        } else {
-            flags.redact_full(&redactable_string, &mut redacted);
-        }
-    })();
+        _ => {}
+    }
 
-    DisplayDebug(redacted)
+    if flags.partial {
+        flags.redact_partial(&redactable_string, &mut redacted);
+    } else {
+        flags.redact_full(&redactable_string, &mut redacted);
+    }
+
+    redacted
+}
+
+pub(crate) fn redact_from_builder(
+    redactable_string: String,
+    flags: RedactFlags,
+    specialization: Option<RedactSpecialization>,
+) -> String {
+    #[cfg(feature = "toggle")]
+    if crate::toggle::get_redaction_behavior().is_plaintext() {
+        return redactable_string;
+    }
+
+    if flags.fixed > 0 {
+        return RedactFlags::redact_fixed(flags.fixed as usize, flags.redact_char);
+    }
+
+    redact_impl(redactable_string, flags, specialization)
+}
+
+pub fn redact(this: RedactionTarget, flags: RedactFlags, specialization: Option<RedactSpecialization>) -> DisplayDebug {
+    let to_redactable_string = || match this {
+        RedactionTarget::Debug { this, alternate: false } => format!("{:?}", this),
+        RedactionTarget::Debug { this, alternate: true } => format!("{:#?}", this),
+        RedactionTarget::Display(this) => this.to_string(),
+    };
+
+    #[cfg(feature = "toggle")]
+    if crate::toggle::get_redaction_behavior().is_plaintext() {
+        return DisplayDebug(to_redactable_string());
+    }
+
+    if flags.fixed > 0 {
+        return DisplayDebug(RedactFlags::redact_fixed(flags.fixed as usize, flags.redact_char));
+    }
+
+    DisplayDebug(redact_impl(to_redactable_string(), flags, specialization))
+}
+
+pub fn redact_pii(this: &dyn Display, flags: RedactFlags) -> String {
+    redact(RedactionTarget::Display(this), flags, None).0
 }

--- a/veil-macros/src/enums.rs
+++ b/veil-macros/src/enums.rs
@@ -183,10 +183,13 @@ pub(super) fn derive_redact(
     Ok(quote! {
         impl #impl_generics ::std::fmt::Debug for #name_ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                let debug_alternate = f.alternate();
+                #[allow(unused)] // Suppresses unused warning with `#[redact(display)]`
+                let alternate = f.alternate();
+
                 match self {
                     #(Self::#variant_idents #variant_destructures => { #variant_bodies; },)*
                 }
+
                 Ok(())
             }
         }

--- a/veil-macros/src/flags.rs
+++ b/veil-macros/src/flags.rs
@@ -1,47 +1,48 @@
 use std::num::NonZeroU8;
 use syn::spanned::Spanned;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct FieldFlags {
-    /// Whether to blanket redact everything (fields, variants)
-    pub all: bool,
-
-    /// Redacts the name of this enum variant, if applicable.
-    pub variant: bool,
-
-    /// Whether the field is partially or fully redacted.
-    ///
-    /// Incompatible with `fixed`.
-    pub partial: bool,
-
-    /// The character to use for redacting. Defaults to `*`.
-    pub redact_char: char,
-
-    /// Whether to redact with a fixed width, ignoring the length of the data.
-    ///
-    /// Incompatible with `partial`.
-    pub fixed: Option<NonZeroU8>,
-
-    /// Whether to skip redaction.
-    ///
-    /// Only allowed if this field is affected by a `#[redact(all)]` attribute.
-    ///
-    /// Fields are not redacted by default unless their parent is marked as `#[redact(all)]`, and this flag turns off that redaction for this specific field.
-    pub skip: bool,
-
-    /// Whether to use the type's [`std::fmt::Display`] implementation instead of [`std::fmt::Debug`].
-    pub display: bool,
+pub struct FieldFlagsParse {
+    pub skip_allowed: bool,
 }
-impl FieldFlags {
-    /// Returns a list of `FieldFlags` parsed from an attribute.
-    ///
-    /// `AMOUNT` is the maximum number of attributes that should be parsed.
-    ///
-    /// `skip_allowed` should be `true` if `#[redact(all)]` is present and this field is affected by it.
-    /// Otherwise, `#[redact(skip)]` is not allowed.
-    pub fn extract<const AMOUNT: usize>(
+
+pub enum TryParseMeta {
+    Consumed,
+    Unrecognised(syn::Meta),
+    Err(syn::Error),
+}
+
+pub trait ExtractFlags: Sized + Copy + Default {
+    type Options;
+
+    fn try_parse_meta(&mut self, meta: syn::Meta) -> TryParseMeta;
+
+    fn parse_meta(
+        &mut self,
+        derive_name: &'static str,
+        attr: &syn::Attribute,
+        meta: syn::Meta,
+    ) -> Result<(), syn::Error> {
+        match self.try_parse_meta(meta) {
+            TryParseMeta::Consumed => Ok(()),
+            TryParseMeta::Err(err) => Err(err),
+            TryParseMeta::Unrecognised(meta) => match meta {
+                // Anything we don't expect
+                syn::Meta::List(_) => Err(syn::Error::new_spanned(
+                    attr,
+                    format!("unexpected list for `{}` attribute", derive_name),
+                )),
+                _ => Err(syn::Error::new_spanned(
+                    attr,
+                    format!("unknown modifier for `{}` attribute", derive_name),
+                )),
+            },
+        }
+    }
+
+    fn extract<const AMOUNT: usize>(
+        derive_name: &'static str,
         attrs: &[syn::Attribute],
-        skip_allowed: bool,
+        options: Self::Options,
     ) -> Result<[Option<Self>; AMOUNT], syn::Error> {
         let mut extracted = [None; AMOUNT];
         let mut head = 0;
@@ -54,27 +55,8 @@ impl FieldFlags {
                 ));
             }
 
-            if let Some(flags) = Self::parse(attr)? {
-                if flags.skip {
-                    if !skip_allowed {
-                        return Err(syn::Error::new(attr.span(), "`#[redact(skip)]` is not allowed here"));
-                    }
-
-                    // It doesn't make sense for `skip` to be present with any other flags.
-                    // We'll throw an error if it is.
-                    let valid_skip_flags = FieldFlags {
-                        skip: true,
-                        variant: flags.variant,
-                        ..Default::default()
-                    };
-                    if flags != valid_skip_flags {
-                        return Err(syn::Error::new(
-                            attr.span(),
-                            "`#[redact(skip)]` should not have any other modifiers present",
-                        ));
-                    }
-                }
-
+            if let Some(flags) = Self::parse(derive_name, attr)? {
+                flags.validate(attr, &options)?;
                 extracted[head] = Some(flags);
                 head += 1;
             }
@@ -83,8 +65,8 @@ impl FieldFlags {
         Ok(extracted)
     }
 
-    fn parse(attr: &syn::Attribute) -> Result<Option<Self>, syn::Error> {
-        let mut flags = FieldFlags::default();
+    fn parse(derive_name: &'static str, attr: &syn::Attribute) -> Result<Option<Self>, syn::Error> {
+        let mut flags = Self::default();
 
         // The modifiers could be a single value or a list, so we need to handle both cases.
         let modifiers = match attr.parse_meta()? {
@@ -103,89 +85,87 @@ impl FieldFlags {
 
         // Now we can finally process each modifier.
         for meta in modifiers {
-            match meta {
-                // #[redact(all)]
-                syn::Meta::Path(path) if path.is_ident("all") => {
-                    flags.all = true;
-                }
-
-                // #[redact(skip)]
-                syn::Meta::Path(path) if path.is_ident("skip") => {
-                    flags.skip = true;
-                }
-
-                // #[redact(partial)]
-                syn::Meta::Path(path) if path.is_ident("partial") => {
-                    flags.partial = true;
-                }
-
-                // #[redact(variant)]
-                syn::Meta::Path(path) if path.is_ident("variant") => {
-                    flags.variant = true;
-                }
-
-                // #[redact(display)]
-                syn::Meta::Path(path) if path.is_ident("display") => {
-                    flags.display = true;
-                }
-
-                // #[redact(with = 'X')]
-                syn::Meta::NameValue(kv) if kv.path.is_ident("with") => match kv.lit {
-                    syn::Lit::Char(with) => flags.redact_char = with.value(),
-                    _ => return Err(syn::Error::new_spanned(kv.lit, "expected a character literal")),
-                },
-
-                // #[redact(fixed = u8)]
-                syn::Meta::NameValue(kv) if kv.path.is_ident("fixed") => match kv.lit {
-                    syn::Lit::Int(int) => {
-                        flags.fixed = Some(NonZeroU8::new(int.base10_parse::<u8>()?).ok_or_else(|| {
-                            syn::Error::new_spanned(int, "fixed redacting width must be greater than zero")
-                        })?)
-                    }
-                    _ => return Err(syn::Error::new_spanned(kv.lit, "expected a character literal")),
-                },
-
-                // Anything we don't expect
-                syn::Meta::List(_) => {
-                    return Err(syn::Error::new_spanned(attr, "unexpected list for `Redact` attribute"))
-                }
-                _ => return Err(syn::Error::new_spanned(attr, "unknown modifier for `Redact` attribute")),
-            }
-        }
-
-        if flags.partial && flags.fixed.is_some() {
-            return Err(syn::Error::new_spanned(
-                attr,
-                "`#[redact(partial)]` and `#[redact(fixed = ...)]` are incompatible",
-            ));
+            flags.parse_meta(derive_name, attr, meta)?;
         }
 
         Ok(Some(flags))
     }
+
+    fn validate(&self, _attr: &syn::Attribute, _options: &Self::Options) -> Result<(), syn::Error> {
+        Ok(())
+    }
 }
-impl Default for FieldFlags {
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct RedactFlags {
+    /// Whether the field is partially or fully redacted.
+    ///
+    /// Incompatible with `fixed`.
+    pub partial: bool,
+
+    /// The character to use for redacting. Defaults to `*`.
+    pub redact_char: char,
+
+    /// Whether to redact with a fixed width, ignoring the length of the data.
+    ///
+    /// Incompatible with `partial`.
+    pub fixed: Option<NonZeroU8>,
+}
+impl Default for RedactFlags {
     fn default() -> Self {
         Self {
             partial: false,
             fixed: None,
             redact_char: '*',
-            variant: false,
-            all: false,
-            skip: false,
-            display: false,
         }
     }
 }
-impl quote::ToTokens for FieldFlags {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        assert!(!self.skip, "internal error: skip flag should not be set here");
+impl ExtractFlags for RedactFlags {
+    type Options = ();
 
+    fn try_parse_meta(&mut self, meta: syn::Meta) -> TryParseMeta {
+        match meta {
+            // #[redact(partial)]
+            syn::Meta::Path(path) if path.is_ident("partial") => {
+                self.partial = true;
+            }
+
+            // #[redact(with = 'X')]
+            syn::Meta::NameValue(kv) if kv.path.is_ident("with") => match kv.lit {
+                syn::Lit::Char(with) => self.redact_char = with.value(),
+                _ => return TryParseMeta::Err(syn::Error::new_spanned(kv.lit, "expected a character literal")),
+            },
+
+            // #[redact(fixed = u8)]
+            syn::Meta::NameValue(kv) if kv.path.is_ident("fixed") => match kv.lit {
+                syn::Lit::Int(int) => {
+                    self.fixed = Some(
+                        match int.base10_parse::<u8>().and_then(|int| {
+                            NonZeroU8::new(int).ok_or_else(|| {
+                                syn::Error::new_spanned(int, "fixed redacting width must be greater than zero")
+                            })
+                        }) {
+                            Ok(fixed) => fixed,
+                            Err(err) => return TryParseMeta::Err(err),
+                        },
+                    )
+                }
+                _ => return TryParseMeta::Err(syn::Error::new_spanned(kv.lit, "expected a character literal")),
+            },
+
+            _ => return TryParseMeta::Unrecognised(meta),
+        }
+        TryParseMeta::Consumed
+    }
+}
+impl quote::ToTokens for RedactFlags {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let Self {
             partial,
             redact_char,
             fixed,
             ..
-        } = *self;
+        } = self;
 
         let fixed = fixed.map(|fixed| fixed.get()).unwrap_or(0);
 
@@ -194,5 +174,106 @@ impl quote::ToTokens for FieldFlags {
             redact_char: #redact_char,
             fixed: #fixed,
         });
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub struct FieldFlags {
+    /// Whether to blanket redact everything (fields, variants)
+    pub all: bool,
+
+    /// Redacts the name of this enum variant, if applicable.
+    pub variant: bool,
+
+    /// Whether to skip redaction.
+    ///
+    /// Only allowed if this field is affected by a `#[redact(all)]` attribute.
+    ///
+    /// Fields are not redacted by default unless their parent is marked as `#[redact(all)]`, and this flag turns off that redaction for this specific field.
+    pub skip: bool,
+
+    /// Whether to use the type's [`std::fmt::Display`] implementation instead of [`std::fmt::Debug`].
+    pub display: bool,
+
+    /// Flags that modify the redaction behavior.
+    pub redact: RedactFlags,
+}
+impl ExtractFlags for FieldFlags {
+    type Options = FieldFlagsParse;
+
+    fn try_parse_meta(&mut self, meta: syn::Meta) -> TryParseMeta {
+        // First try to parse the redaction flags.
+        let meta = match self.redact.try_parse_meta(meta) {
+            // This was a redaction flag, so we don't need to do anything else.
+            // OR
+            // This was an error, so we need to propagate it.
+            result @ (TryParseMeta::Consumed | TryParseMeta::Err(_)) => return result,
+
+            // This was not a redaction flag, so we need to continue processing.
+            TryParseMeta::Unrecognised(meta) => meta,
+        };
+
+        match meta {
+            // #[redact(all)]
+            syn::Meta::Path(path) if path.is_ident("all") => {
+                self.all = true;
+            }
+
+            // #[redact(skip)]
+            syn::Meta::Path(path) if path.is_ident("skip") => {
+                self.skip = true;
+            }
+
+            // #[redact(variant)]
+            syn::Meta::Path(path) if path.is_ident("variant") => {
+                self.variant = true;
+            }
+
+            // #[redact(display)]
+            syn::Meta::Path(path) if path.is_ident("display") => {
+                self.display = true;
+            }
+
+            _ => return TryParseMeta::Unrecognised(meta),
+        }
+
+        TryParseMeta::Consumed
+    }
+
+    fn validate(&self, attr: &syn::Attribute, options: &Self::Options) -> Result<(), syn::Error> {
+        if self.skip {
+            if !options.skip_allowed {
+                return Err(syn::Error::new(attr.span(), "`#[redact(skip)]` is not allowed here"));
+            }
+
+            // It doesn't make sense for `skip` to be present with any other flags.
+            // We'll throw an error if it is.
+            let valid_skip_flags = FieldFlags {
+                skip: true,
+                variant: self.variant,
+                ..Default::default()
+            };
+            if self != &valid_skip_flags {
+                return Err(syn::Error::new(
+                    attr.span(),
+                    "`#[redact(skip)]` should not have any other modifiers present",
+                ));
+            }
+        }
+
+        if self.redact.partial && self.redact.fixed.is_some() {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "`#[redact(partial)]` and `#[redact(fixed = ...)]` are incompatible",
+            ));
+        }
+
+        Ok(())
+    }
+}
+impl quote::ToTokens for FieldFlags {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        assert!(!self.skip, "internal error: skip flag should not be set here");
+        self.redact.to_tokens(tokens)
     }
 }

--- a/veil-macros/src/flags.rs
+++ b/veil-macros/src/flags.rs
@@ -28,6 +28,9 @@ pub struct FieldFlags {
     ///
     /// Fields are not redacted by default unless their parent is marked as `#[redact(all)]`, and this flag turns off that redaction for this specific field.
     pub skip: bool,
+
+    /// Whether to use the type's [`std::fmt::Display`] implementation instead of [`std::fmt::Debug`].
+    pub display: bool,
 }
 impl FieldFlags {
     /// Returns a list of `FieldFlags` parsed from an attribute.
@@ -121,6 +124,11 @@ impl FieldFlags {
                     flags.variant = true;
                 }
 
+                // #[redact(display)]
+                syn::Meta::Path(path) if path.is_ident("display") => {
+                    flags.display = true;
+                }
+
                 // #[redact(with = 'X')]
                 syn::Meta::NameValue(kv) if kv.path.is_ident("with") => match kv.lit {
                     syn::Lit::Char(with) => flags.redact_char = with.value(),
@@ -164,6 +172,7 @@ impl Default for FieldFlags {
             variant: false,
             all: false,
             skip: false,
+            display: false,
         }
     }
 }

--- a/veil-macros/src/fmt.rs
+++ b/veil-macros/src/fmt.rs
@@ -152,12 +152,28 @@ pub(crate) fn generate_redact_call(
         // This is the one place where we actually track whether the derive macro had any effect! Nice.
         unused.redacted_something();
 
-        quote! {
-            ::veil::private::redact(#field_accessor, ::veil::private::RedactFlags {
-                debug_alternate,
-                is_option: #is_option,
-                #field_flags
-            })
+        if field_flags.display {
+            // std::fmt::Display
+            quote! {
+                ::veil::private::redact(
+                    ::veil::private::RedactionTarget::Display(#field_accessor),
+                    ::veil::private::RedactFlags {
+                        is_option: #is_option,
+                        #field_flags
+                    }
+                )
+            }
+        } else {
+            // std::fmt::Debug
+            quote! {
+                ::veil::private::redact(
+                    ::veil::private::RedactionTarget::Debug { this: #field_accessor, alternate },
+                    ::veil::private::RedactFlags {
+                        is_option: #is_option,
+                        #field_flags
+                    }
+                )
+            }
         }
     } else {
         field_accessor

--- a/veil-macros/src/lib.rs
+++ b/veil-macros/src/lib.rs
@@ -1,23 +1,28 @@
+//! Macros for [`veil`].
+
+#![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
+
 #[macro_use]
 extern crate quote;
 
 mod enums;
 mod flags;
 mod fmt;
+mod pii;
+mod redact;
 mod sanitize;
 mod structs;
 
 use proc_macro::TokenStream;
-use sanitize::DeriveAttributeFilter;
-use syn::spanned::Spanned;
 
 /// Keep track of whether we actually redact anything.
 ///
-/// By default fields are not redacted. One must add #[redact(...)] to them.
+/// By default fields are not redacted. One must add `#[redact(...)]` to them.
 ///
 /// We should throw an error if no fields are redacted, because the user should derive Debug instead.
 ///
-/// This should also be aware of #[redact(skip)] - we shouldn't let users bypass this check via that.
+/// This should also be aware of `#[redact(skip)]` - we shouldn't let users bypass this check via that.
 struct UnusedDiagnostic(bool);
 impl UnusedDiagnostic {
     #[inline(always)]
@@ -39,45 +44,22 @@ impl Default for UnusedDiagnostic {
     }
 }
 
-#[proc_macro_derive(Redact, attributes(redact))]
-/// Implements [`std::fmt::Debug`] for a struct or enum variant, with certain fields redacted.
+#[proc_macro_derive(Pii, attributes(redact))]
+/// Implements [`RedactPii`](trait.RedactPii.html) for a type.
 ///
-/// See the [crate level documentation](index.html) for more information.
+/// The type must have a [`std::fmt::Display`] implementation. This is what will be used to redact the type.
+///
+/// See the [crate level documentation](index.html) for flags and modifiers.
+pub fn derive_pii(item: TokenStream) -> TokenStream {
+    pii::derive(item)
+}
+
+#[proc_macro_derive(Redact, attributes(redact))]
+/// Implements [`std::fmt::Debug`] for a struct or enum, with certain fields redacted.
+///
+/// See the [crate level documentation](index.html) for flags and modifiers.
 pub fn derive_redact(item: TokenStream) -> TokenStream {
-    let mut item = syn::parse_macro_input!(item as syn::DeriveInput);
-
-    // Remove all non-veil attributes to avoid conflicting with other
-    // derive proc macro attributes.
-    item.retain_veil_attrs();
-
-    // Unfortunately this is somewhat complex to implement at this stage of the macro "pipeline",
-    // so we'll pass around a mutable reference to this variable, and set it to false if we redact anything.
-    // TBH this kind of smells, but I can't think of a better way to do it.
-    let mut unused = UnusedDiagnostic::default();
-
-    let item_span = item.span();
-
-    let result = match item.data {
-        syn::Data::Struct(s) => structs::derive_redact(s, item.generics, item.attrs, item.ident, &mut unused),
-        syn::Data::Enum(e) => enums::derive_redact(e, item.generics, item.attrs, item.ident, &mut unused),
-        syn::Data::Union(_) => Err(syn::Error::new(item_span, "this trait cannot be derived for unions")),
-    };
-
-    let result = result.and_then(|tokens| {
-        if unused.should_throw_err() {
-            Err(syn::Error::new(
-                item_span,
-                "`#[derive(Redact)]` does nothing by default, you must specify at least one field to redact. You should `#[derive(Debug)]` instead if this is intentional",
-            ))
-        } else {
-            Ok(tokens)
-        }
-    });
-
-    match result {
-        Ok(tokens) => tokens,
-        Err(err) => err.into_compile_error().into(),
-    }
+    redact::derive(item)
 }
 
 #[doc(hidden)]

--- a/veil-macros/src/pii.rs
+++ b/veil-macros/src/pii.rs
@@ -1,0 +1,80 @@
+use crate::{
+    flags::{ExtractFlags, RedactFlags},
+    sanitize::{AttributeFilter, DeriveAttributeFilter},
+};
+use proc_macro::TokenStream;
+use syn::spanned::Spanned;
+
+fn try_derive(mut item: syn::DeriveInput) -> Result<TokenStream, syn::Error> {
+    // Remove all non-veil attributes to avoid conflicting with other
+    // derive proc macro attributes.
+    item.retain_veil_attrs();
+
+    let item_span = item.span();
+
+    let s = match item.data {
+        syn::Data::Struct(s) => s,
+        syn::Data::Enum(_) => return Err(syn::Error::new(item_span, "this trait cannot be derived for enums")),
+        syn::Data::Union(_) => return Err(syn::Error::new(item_span, "this trait cannot be derived for unions")),
+    };
+
+    let mut field = match s.fields.len() {
+        0 => {
+            return Err(syn::Error::new(
+                item_span,
+                "this trait cannot be derived for structs with no fields",
+            ))
+        }
+        1 => s.fields.into_iter().next().unwrap(),
+        _ => {
+            return Err(syn::Error::new(
+                item_span,
+                "this trait cannot be derived for structs with multiple fields",
+            ))
+        }
+    };
+
+    field.attrs.retain_veil_attrs();
+
+    if !field.attrs.is_empty() {
+        return Err(syn::Error::new(
+            field.attrs[0].span(),
+            "redaction modifiers are not allowed here, put them on the struct itself",
+        ));
+    }
+
+    let flags = RedactFlags::extract::<1>("Pii", &item.attrs, ())?[0].unwrap_or_default();
+
+    let name_ident = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+    Ok(quote! {
+        impl #impl_generics ::veil::RedactPii for #name_ident #ty_generics #where_clause {
+            fn redact(&self) -> String {
+                ::veil::private::redact_pii(
+                    self,
+                    ::veil::private::RedactFlags { #flags }
+                )
+            }
+
+            fn redact_into<W: ::std::fmt::Write>(&self, buffer: &mut W) -> ::std::fmt::Result {
+                buffer.write_str(
+                    ::veil::private::redact_pii(
+                        self,
+                        ::veil::private::RedactFlags { #flags }
+                    )
+                    .as_str()
+                )
+            }
+        }
+    }
+    .into())
+}
+
+pub fn derive(item: TokenStream) -> TokenStream {
+    let item = syn::parse_macro_input!(item as syn::DeriveInput);
+
+    match try_derive(item) {
+        Ok(tokens) => tokens,
+        Err(err) => err.into_compile_error().into(),
+    }
+}

--- a/veil-macros/src/redact.rs
+++ b/veil-macros/src/redact.rs
@@ -1,0 +1,40 @@
+use crate::{enums, sanitize::DeriveAttributeFilter, structs, UnusedDiagnostic};
+use proc_macro::TokenStream;
+use syn::spanned::Spanned;
+
+fn try_derive(mut item: syn::DeriveInput) -> Result<TokenStream, syn::Error> {
+    // Remove all non-veil attributes to avoid conflicting with other
+    // derive proc macro attributes.
+    item.retain_veil_attrs();
+
+    let item_span = item.span();
+
+    // Unfortunately this is somewhat complex to implement at this stage of the macro "pipeline",
+    // so we'll pass around a mutable reference to this variable, and set it to false if we redact anything.
+    // TBH this kind of smells, but I can't think of a better way to do it.
+    let mut unused = UnusedDiagnostic::default();
+
+    let tokens = match item.data {
+        syn::Data::Struct(s) => structs::derive_redact(s, item.generics, item.attrs, item.ident, &mut unused)?,
+        syn::Data::Enum(e) => enums::derive_redact(e, item.generics, item.attrs, item.ident, &mut unused)?,
+        syn::Data::Union(_) => return Err(syn::Error::new(item_span, "this trait cannot be derived for unions")),
+    };
+
+    if unused.should_throw_err() {
+        return Err(syn::Error::new(
+            item_span,
+            "`#[derive(Redact)]` does nothing by default, you must specify at least one field to redact. You should `#[derive(Debug)]` instead if this is intentional",
+        ));
+    }
+
+    Ok(tokens)
+}
+
+pub fn derive(item: TokenStream) -> TokenStream {
+    let item = syn::parse_macro_input!(item as syn::DeriveInput);
+
+    match try_derive(item) {
+        Ok(tokens) => tokens,
+        Err(err) => err.into_compile_error().into(),
+    }
+}

--- a/veil-macros/src/sanitize.rs
+++ b/veil-macros/src/sanitize.rs
@@ -1,4 +1,4 @@
-trait AttributeFilter {
+pub(crate) trait AttributeFilter {
     fn retain_veil_attrs(&mut self);
 }
 impl AttributeFilter for Vec<syn::Attribute> {

--- a/veil-macros/src/structs.rs
+++ b/veil-macros/src/structs.rs
@@ -62,8 +62,11 @@ pub(super) fn derive_redact(
     Ok(quote! {
         impl #impl_generics ::std::fmt::Debug for #name_ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                let debug_alternate = f.alternate();
+                #[allow(unused)] // Suppresses unused warning with `#[redact(display)]`
+                let alternate = f.alternate();
+
                 #impl_debug;
+
                 Ok(())
             }
         }

--- a/veil-macros/src/structs.rs
+++ b/veil-macros/src/structs.rs
@@ -1,4 +1,8 @@
-use crate::{flags::FieldFlags, fmt::FormatData, UnusedDiagnostic};
+use crate::{
+    flags::{ExtractFlags, FieldFlags, FieldFlagsParse},
+    fmt::FormatData,
+    UnusedDiagnostic,
+};
 use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::spanned::Spanned;
@@ -13,7 +17,7 @@ pub(super) fn derive_redact(
     // Parse #[redact(all, variant, ...)] from the enum attributes, if present.
     let top_level_flags = match attrs.len() {
         0 => None,
-        1 => match FieldFlags::extract::<1>(&attrs, false)? {
+        1 => match FieldFlags::extract::<1>("Redact", &attrs, FieldFlagsParse { skip_allowed: false })? {
             [Some(flags)] => {
                 if flags.variant {
                     return Err(syn::Error::new(

--- a/veil-tests/src/compile_tests/fail.rs
+++ b/veil-tests/src/compile_tests/fail.rs
@@ -18,5 +18,10 @@ fail_tests! {
     redact_union,
     redact_units,
     redact_skip,
-    redact_missing_all
+    redact_missing_all,
+    pii_empty_struct,
+    pii_inner_flags,
+    pii_multiple_fields,
+    pii_non_struct,
+    pii_unknown_flag
 }

--- a/veil-tests/src/compile_tests/fail/pii_empty_struct.rs
+++ b/veil-tests/src/compile_tests/fail/pii_empty_struct.rs
@@ -1,0 +1,4 @@
+fn main() {}
+
+#[derive(veil::Pii)]
+struct EmptyStruct;

--- a/veil-tests/src/compile_tests/fail/pii_empty_struct.stderr
+++ b/veil-tests/src/compile_tests/fail/pii_empty_struct.stderr
@@ -1,0 +1,5 @@
+error: this trait cannot be derived for structs with no fields
+ --> src/compile_tests/fail/pii_empty_struct.rs:4:1
+  |
+4 | struct EmptyStruct;
+  | ^^^^^^

--- a/veil-tests/src/compile_tests/fail/pii_inner_flags.rs
+++ b/veil-tests/src/compile_tests/fail/pii_inner_flags.rs
@@ -1,0 +1,7 @@
+fn main() {}
+
+#[derive(veil::Pii)]
+struct Foo {
+    #[redact(partial)]
+    bar: String
+}

--- a/veil-tests/src/compile_tests/fail/pii_inner_flags.stderr
+++ b/veil-tests/src/compile_tests/fail/pii_inner_flags.stderr
@@ -1,0 +1,5 @@
+error: redaction modifiers are not allowed here, put them on the struct itself
+ --> src/compile_tests/fail/pii_inner_flags.rs:5:5
+  |
+5 |     #[redact(partial)]
+  |     ^

--- a/veil-tests/src/compile_tests/fail/pii_multiple_fields.rs
+++ b/veil-tests/src/compile_tests/fail/pii_multiple_fields.rs
@@ -1,0 +1,7 @@
+fn main() {}
+
+#[derive(veil::Pii)]
+struct Foo {
+    bar: String,
+    baz: String
+}

--- a/veil-tests/src/compile_tests/fail/pii_multiple_fields.stderr
+++ b/veil-tests/src/compile_tests/fail/pii_multiple_fields.stderr
@@ -1,0 +1,5 @@
+error: this trait cannot be derived for structs with multiple fields
+ --> src/compile_tests/fail/pii_multiple_fields.rs:4:1
+  |
+4 | struct Foo {
+  | ^^^^^^

--- a/veil-tests/src/compile_tests/fail/pii_non_struct.rs
+++ b/veil-tests/src/compile_tests/fail/pii_non_struct.rs
@@ -1,0 +1,9 @@
+fn main() {}
+
+#[derive(veil::Pii)]
+enum Foo {}
+
+#[derive(veil::Pii)]
+union Bar {
+    a: i32
+}

--- a/veil-tests/src/compile_tests/fail/pii_non_struct.stderr
+++ b/veil-tests/src/compile_tests/fail/pii_non_struct.stderr
@@ -1,0 +1,11 @@
+error: this trait cannot be derived for enums
+ --> src/compile_tests/fail/pii_non_struct.rs:4:1
+  |
+4 | enum Foo {}
+  | ^^^^
+
+error: this trait cannot be derived for unions
+ --> src/compile_tests/fail/pii_non_struct.rs:7:1
+  |
+7 | union Bar {
+  | ^^^^^

--- a/veil-tests/src/compile_tests/fail/pii_unknown_flag.rs
+++ b/veil-tests/src/compile_tests/fail/pii_unknown_flag.rs
@@ -1,0 +1,19 @@
+fn main() {}
+
+#[derive(veil::Pii)]
+#[redact(skip)]
+struct Foo {
+    inner: String
+}
+
+#[derive(veil::Pii)]
+#[redact(all)]
+struct Bar {
+    inner: String
+}
+
+#[derive(veil::Pii)]
+#[redact(blah)]
+struct Baz {
+    inner: String
+}

--- a/veil-tests/src/compile_tests/fail/pii_unknown_flag.stderr
+++ b/veil-tests/src/compile_tests/fail/pii_unknown_flag.stderr
@@ -1,0 +1,17 @@
+error: unknown modifier for `Pii` attribute
+ --> src/compile_tests/fail/pii_unknown_flag.rs:4:1
+  |
+4 | #[redact(skip)]
+  | ^^^^^^^^^^^^^^^
+
+error: unknown modifier for `Pii` attribute
+  --> src/compile_tests/fail/pii_unknown_flag.rs:10:1
+   |
+10 | #[redact(all)]
+   | ^^^^^^^^^^^^^^
+
+error: unknown modifier for `Pii` attribute
+  --> src/compile_tests/fail/pii_unknown_flag.rs:16:1
+   |
+16 | #[redact(blah)]
+   | ^^^^^^^^^^^^^^^

--- a/veil-tests/src/redaction_tests.rs
+++ b/veil-tests/src/redaction_tests.rs
@@ -147,3 +147,15 @@ fn test_sensitive_tuple_structs() {
         SENSITIVE_DATA[3],
     ));
 }
+
+#[test]
+fn test_display_redaction() {
+    #[derive(Redact)]
+    struct RedactDisplay(#[redact(display)] String);
+
+    #[derive(Redact)]
+    struct RedactDebug(#[redact] String);
+
+    assert_eq!(format!("{:?}", RedactDebug("\"".to_string())), r#"RedactDebug("\"")"#);
+    assert_eq!(format!("{:?}", RedactDisplay("\"".to_string())), r#"RedactDisplay(")"#);
+}


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-837

Bit of a big one here...

This PR is hoping to resolve issues described in [this Slack thread](https://prima.slack.com/archives/C01C70U9F37/p1670860264520579)

Main changes:

* Added `RedactPii` (trait) and `Pii` (derive macro for trait), which allow for manual and explicit redaction formatting of data
* Added `RedactorBuilder` and `Redactor`, which allow for redacting arbitrary strings with familiar flags as described in the crate root documentation
* Some internal refactors to improve performance and share reused code
* Added tests and doctests for these changes
