### PR TITLE
[PLATFORM-861]: Fix borked enum variant name formatting

### DIFF
--- a/veil-macros/src/enums.rs
+++ b/veil-macros/src/enums.rs
@@ -168,7 +168,7 @@ pub(super) fn derive_redact(
     for (variant, flags) in e.variants.iter().zip(variant_flags.into_iter()) {
         // Variant name redacting
         let variant_name = variant.ident.to_string();
-        let variant_name = if let Some(flags) = &flags.variant_flags {
+        let variant_name = if let Some(flags @ FieldFlags { skip: false, .. }) = &flags.variant_flags {
             // The variant name must always be formatted with the Display impl.
             let flags = FieldFlags {
                 display: true,


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-861

Fixes a weird edge case where enum variant names were not being formatted correctly.

Added tests to ensure that we don't regress this in future.
