### PR TITLE
[PLATFORM-863]: Improve code coverage test for error messages in Veil

### DIFF
--- a/veil-tests/src/code_coverage.rs
+++ b/veil-tests/src/code_coverage.rs
@@ -18,8 +18,8 @@ fn test_code_coverage_for_errors() {
         code_coverage: Vec<&'b OsStr>,
     }
     impl std::fmt::Debug for ErrorMessage<'_, '_> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("ErrorMessage")
+        fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fmt.debug_struct("ErrorMessage")
                 .field(
                     "message",
                     &self
@@ -100,7 +100,7 @@ fn test_code_coverage_for_errors() {
         macro_src_files.push(SourceFile::new(path).expect("Failed to read veil-macros src file"));
     }
 
-    let re_syn_error = regex::Regex::new(r#"syn::Error::new\(\s*.+?,\s*"(.+?)",?\s*\)"#).unwrap();
+    let re_syn_error = regex::Regex::new(r#"syn::Error::new(?:_spanned)?\(\s*.+?,\s*"(.+?)",?\s*\)"#).unwrap();
     for src in macro_src_files.iter() {
         for cap in re_syn_error.captures_iter(&src.contents) {
             let error_msg = cap.get(1).unwrap();

--- a/veil-tests/src/compile_tests/fail.rs
+++ b/veil-tests/src/compile_tests/fail.rs
@@ -7,6 +7,7 @@ macro_rules! fail_tests {
     )*};
 }
 fail_tests! {
+    redact_invalid_flags,
     redact_all_on_field,
     redact_all_variant_on_variant,
     redact_enum_without_variant,

--- a/veil-tests/src/compile_tests/fail/redact_invalid_flags.rs
+++ b/veil-tests/src/compile_tests/fail/redact_invalid_flags.rs
@@ -1,0 +1,7 @@
+fn main() {}
+
+#[derive(veil::Redact)]
+struct InvalidChar(#[redact(with = "this isn't a char")] ());
+
+#[derive(veil::Redact)]
+struct InvalidFixedWidth(#[redact(fixed = 0)] ());

--- a/veil-tests/src/compile_tests/fail/redact_invalid_flags.stderr
+++ b/veil-tests/src/compile_tests/fail/redact_invalid_flags.stderr
@@ -1,0 +1,13 @@
+error: expected a character literal
+ --> src/compile_tests/fail/redact_invalid_flags.rs:4:36
+  |
+4 | struct InvalidChar(#[redact(with = "this isn't a char")] ());
+  |                                    ^^^^^^^^^^^^^^^^^^^
+
+error: fixed redacting width must be greater than zero
+ --> src/compile_tests/fail/redact_invalid_flags.rs:6:10
+  |
+6 | #[derive(veil::Redact)]
+  |          ^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `veil::Redact` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-863

This PR introduces a change to the code coverage test for error messages that catches a instances of syn::Error::new_spanned.

I have also added the missing tests to improve the said code coverage.
