### PR TITLE
Fix redaction of options

### DIFF
--- a/examples/customer.rs
+++ b/examples/customer.rs
@@ -11,7 +11,7 @@ pub struct Customer {
     last_name: String,
 
     #[redact]
-    email: String,
+    email: Option<String>,
 
     #[redact(fixed = 2)]
     age: u32,
@@ -24,7 +24,7 @@ fn main() {
             id: 1,
             first_name: "John".to_string(),
             last_name: "Doe".to_string(),
-            email: "johndoe@example.com".to_string(),
+            email: Some("johndoe@example.com".to_string()),
             age: 30,
         }
     );

--- a/src/private.rs
+++ b/src/private.rs
@@ -167,7 +167,11 @@ impl std::fmt::Debug for RedactionFormatter<'_> {
                     .and_then(|inner| inner.strip_suffix(')'))
                 {
                     fmt.write_str("Some(")?;
-                    self.flags.redact_partial(fmt, inner)?;
+                    if let RedactionLength::Partial = &self.flags.redact_length {
+                        self.flags.redact_partial(fmt, inner)?;
+                    } else {
+                        self.flags.redact_full(fmt, inner)?;
+                    }
                     return fmt.write_char(')');
                 } else {
                     // This should never happen, but just in case...

--- a/veil-tests/src/redaction_tests.rs
+++ b/veil-tests/src/redaction_tests.rs
@@ -136,7 +136,14 @@ fn test_sensitive_structs_with_options() {
     }
 
     assert_eq!(
-        format!("{:?}", SensitiveStruct { data1: Some("1234567890"), data2: Some("1234567890"), data3: None }),
+        format!(
+            "{:?}",
+            SensitiveStruct {
+                data1: Some("1234567890"),
+                data2: Some("1234567890"),
+                data3: None
+            }
+        ),
         "SensitiveStruct { data1: Some(\"**********\"), data2: Some(\"123****890\"), data3: None }"
     );
 }

--- a/veil-tests/src/redaction_tests.rs
+++ b/veil-tests/src/redaction_tests.rs
@@ -122,6 +122,26 @@ fn test_sensitive_structs() {
 }
 
 #[test]
+fn test_sensitive_structs_with_options() {
+    #[derive(Redact)]
+    struct SensitiveStruct {
+        #[redact]
+        data1: Option<&'static str>,
+
+        #[redact(partial)]
+        data2: Option<&'static str>,
+
+        #[redact]
+        data3: Option<&'static str>,
+    }
+
+    assert_eq!(
+        format!("{:?}", SensitiveStruct { data1: Some("1234567890"), data2: Some("1234567890"), data3: None }),
+        "SensitiveStruct { data1: Some(\"**********\"), data2: Some(\"123****890\"), data3: None }"
+    );
+}
+
+#[test]
 fn test_sensitive_tuple_structs() {
     #[derive(Redact)]
     struct SensitiveStruct(


### PR DESCRIPTION
Currently on `master` there is a bug which hardcodes partial redaction for Options. 
The exact line can be found here: https://github.com/primait/veil/pull/75/files#diff-db6d7ee4e2c406f36b3c82c694cbe07a593a6b7c6f4c7585a742c9990560810cL170

I have added a new test to `veil-tests/src/redaction_tests.rs` which demonstrates this bug if you run it without any of the other code introduced in this PR. That new test will pass with the code introduced here (really just a copy-paste from other code in the repo).