### PR TITLE
adds support for re-exporting crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.0] - 2024-10-30
+
+### Changed
+
+- Breaking: de-anchor veil inputs, to allow for reimporting.
+
+This might cause issues in some very rare cases, but generally shouldn't require any changes.
+
+---
+
 ## [0.1.7] - 2023-11-20
 
 ### Changed
@@ -21,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated to syn v2
 
-[Unreleased]: https://github.com/primait/veil/compare/0.1.7...HEAD
+
+[Unreleased]: https://github.com/primait/veil/compare/0.2.0...HEAD
+[0.2.0]: https://github.com/primait/veil/compare/0.1.7...0.2.0
 [0.1.7]: https://github.com/primait/veil/compare/0.1.6...0.1.7
 [0.1.6]: https://github.com/primait/veil/compare/0.1.5...0.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Breaking: de-anchor veil imports, to allow for reimporting.
+- Breaking: de-anchor veil imports, to allow for reexporting.
 
 This might cause issues in some very rare cases, but generally shouldn't require any changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Breaking: de-anchor veil inputs, to allow for reimporting.
+- Breaking: de-anchor veil imports, to allow for reimporting.
 
 This might cause issues in some very rare cases, but generally shouldn't require any changes.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veil"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 description = "Rust derive macro for redacting sensitive data in `std::fmt::Debug`"
 license = "MIT OR Apache-2.0"
@@ -28,7 +28,7 @@ name = "disable_redaction"
 required-features = ["toggle"]
 
 [dependencies]
-veil-macros = { path = "veil-macros", version = "=0.1.7" }
+veil-macros = { path = "veil-macros", version = "=0.2.0" }
 once_cell = "1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add to your Cargo.toml:
 
 ```toml
 [dependencies]
-veil = "0.1.7"
+veil = "0.2.0"
 ```
 
 Usage documentation can be found [here](https://docs.rs/veil).

--- a/src/private.rs
+++ b/src/private.rs
@@ -11,13 +11,13 @@ pub enum RedactSpecialization {
     /// This could be improved & rid of in a number of different ways in the future:
     ///
     /// * Once specialization is stabilized, we can use a trait to override redacting behavior for some types,
-    /// one of which would be [`Option<T>`].
+    ///   one of which would be [`Option<T>`].
     ///
     /// * Once std::ptr::metadata and friends are stabilized, we could use it to unsafely cast the dyn Debug pointer
-    /// to a concrete [`Option<T>`] and redact it directly. Probably not the best idea.
+    ///   to a concrete [`Option<T>`] and redact it directly. Probably not the best idea.
     ///
     /// * Once trait upcasting is stabilized, we could use it to upcast the dyn Debug pointer to a dyn Any and then
-    /// downcast it to a concrete [`Option<T>`] and redact it directly.
+    ///   downcast it to a concrete [`Option<T>`] and redact it directly.
     Option,
 }
 
@@ -127,12 +127,13 @@ impl RedactionTarget<'_> {
         }
     }
 }
-impl ToString for RedactionTarget<'_> {
-    fn to_string(&self) -> String {
+
+impl Display for RedactionTarget<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match self {
-            RedactionTarget::Debug { this, alternate: false } => format!("{:?}", this),
-            RedactionTarget::Debug { this, alternate: true } => format!("{:#?}", this),
-            RedactionTarget::Display(this) => this.to_string(),
+            RedactionTarget::Debug { this, alternate: false } => write!(f, "{:?}", this),
+            RedactionTarget::Debug { this, alternate: true } => write!(f, "{:#?}", this),
+            RedactionTarget::Display(this) => write!(f, "{}", this),
         }
     }
 }

--- a/src/redactor.rs
+++ b/src/redactor.rs
@@ -214,3 +214,9 @@ impl RedactorBuilder {
         Ok(Redactor(flags))
     }
 }
+
+impl Default for RedactorBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/veil-macros/Cargo.toml
+++ b/veil-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veil-macros"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 description = "Veil procedural macros"
 license = "MIT OR Apache-2.0"

--- a/veil-macros/src/flags.rs
+++ b/veil-macros/src/flags.rs
@@ -88,11 +88,11 @@ pub enum RedactionLength {
 impl quote::ToTokens for RedactionLength {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         match self {
-            RedactionLength::Full => quote! { ::veil::private::RedactionLength::Full }.to_tokens(tokens),
-            RedactionLength::Partial => quote! { ::veil::private::RedactionLength::Partial }.to_tokens(tokens),
+            RedactionLength::Full => quote! { veil::private::RedactionLength::Full }.to_tokens(tokens),
+            RedactionLength::Partial => quote! { veil::private::RedactionLength::Partial }.to_tokens(tokens),
             RedactionLength::Fixed(n) => {
                 let n = n.get();
-                quote! { ::veil::private::RedactionLength::Fixed(::core::num::NonZeroU8::new(#n).unwrap()) }
+                quote! { veil::private::RedactionLength::Fixed(::core::num::NonZeroU8::new(#n).unwrap()) }
                     .to_tokens(tokens)
             }
         }

--- a/veil-macros/src/fmt.rs
+++ b/veil-macros/src/fmt.rs
@@ -162,7 +162,7 @@ pub(crate) fn generate_redact_call(
         unused.redacted_something();
 
         let specialization = if is_option {
-            quote! { ::std::option::Option::Some(::veil::private::RedactSpecialization::Option) }
+            quote! { ::std::option::Option::Some(veil::private::RedactSpecialization::Option) }
         } else {
             quote! { ::std::option::Option::None }
         };
@@ -170,18 +170,18 @@ pub(crate) fn generate_redact_call(
         if field_flags.display {
             // std::fmt::Display
             quote! {
-                &::veil::private::RedactionFormatter {
-                    this: ::veil::private::RedactionTarget::Display(#field_accessor),
-                    flags: ::veil::private::RedactFlags { #field_flags },
+                &veil::private::RedactionFormatter {
+                    this: veil::private::RedactionTarget::Display(#field_accessor),
+                    flags: veil::private::RedactFlags { #field_flags },
                     specialization: #specialization
                 }
             }
         } else {
             // std::fmt::Debug
             quote! {
-                &::veil::private::RedactionFormatter {
-                    this: ::veil::private::RedactionTarget::Debug { this: #field_accessor, alternate },
-                    flags: ::veil::private::RedactFlags { #field_flags },
+                &veil::private::RedactionFormatter {
+                    this: veil::private::RedactionTarget::Debug { this: #field_accessor, alternate },
+                    flags: veil::private::RedactFlags { #field_flags },
                     specialization: #specialization
                 }
             }

--- a/veil-macros/src/redactable.rs
+++ b/veil-macros/src/redactable.rs
@@ -48,19 +48,19 @@ fn try_derive(mut item: syn::DeriveInput) -> Result<TokenStream, syn::Error> {
     let name_ident = &item.ident;
     let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
     Ok(quote! {
-        impl #impl_generics ::veil::Redactable for #name_ident #ty_generics #where_clause {
+        impl #impl_generics veil::Redactable for #name_ident #ty_generics #where_clause {
             fn redact(&self) -> String {
-                ::veil::private::derived_redactable(
+                veil::private::derived_redactable(
                     self,
-                    ::veil::private::RedactFlags { #flags }
+                    veil::private::RedactFlags { #flags }
                 )
             }
 
             fn redact_into(&self, buffer: &mut dyn ::std::fmt::Write) -> ::std::fmt::Result {
                 buffer.write_str(
-                    ::veil::private::derived_redactable(
+                    veil::private::derived_redactable(
                         self,
-                        ::veil::private::RedactFlags { #flags }
+                        veil::private::RedactFlags { #flags }
                     )
                     .as_str()
                 )


### PR DESCRIPTION
Heyo! Thanks for making `veil`, it's useful!

I'd like to request (and provide) a small change that makes it possible to use `veil` in a way that it doesn't currently support.

As it stands, the `::veil` paths are anchored, which requires the depending crate to directly depend on `veil`. That's suitable for most cases (clearly, since it only works this way currently), but it also makes it so that importing it from a crate that re-exports it doesn't work. This in turn makes it difficult to provide a batteries-included sort of functionality in downstream crates.

This change removes the path anchors, and to the best of my knowledge should not break anything, except what I assume would be an unusual scenario where another module exists in the same scope that also happens to be named `veil`. This puts the responsibility on whoever does _that_ to anchor the reference **there**, which seems like a fair trade.

The test suite still runs (and passes!), and I haven't done anything with the versioning, since while I'm pretty sure that this won't cause any issues, I'm still not quite clear on how that would intersect with versioning. 🤔

If you'd like me to change anything, just let me know and I'd be happy to do my best!

Thanks again, people like you making cool things is why we have so much great stuff in the Rust ecosystem. ❤️ 