### PR TITLE
Rename catalog-info.yaml to backstage-catalog.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,9 +1,0 @@
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: veil
-  description: Rust derive macro for redacting sensitive data in `std::fmt::Debug`
-spec:
-  type: library
-  lifecycle: production
-  owner: team-developer-experience


### PR DESCRIPTION
When the name of the backstage file is catalog-info, it conflicts with the Datadog Software Catalog configuration. This change renames the file to stop the file being read by datadog (which should read the service.datadog.yaml) but make sure that Backstage can still read it