### PR TITLE
Implemented all_utf8 option to redact all unicode characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! The purpose of this macro is to allow for easy, configurable and efficient redaction of sensitive data in structs and enum variants.
 //! This can be used to hide sensitive data in logs or anywhere where personal data should not be exposed or stored.
 //!
-//! Redaction is unicode-aware. Only alphanumeric characters are redacted. Whitespace, symbols and other characters are left as-is.
+//! Redaction is unicode-aware by default. Unless opted out of, only alphanumeric characters are redacted. Whitespace, symbols and other characters are left as-is.
 //!
 //! # Controlling Redaction
 //!
@@ -19,6 +19,7 @@
 //! | **Modifier**                   |   | **Effects**                                                                                                                                                                          |   | **Default**                                   |
 //! |--------------------------------|---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|-----------------------------------------------|
 //! | `#[redact(partial)]`           |   | If the string is long enough, a small part of the<br>beginning and end will be exposed. If the string is too short to securely expose a portion of it, it will be redacted entirely. |   | Disabled. The entire string will be redacted. |
+//! | `#[redact(all_utf8)]`          |   | Overrides the redaction behavior to redact all characters instead of just alphanumeric characters.                                                                                   |   | Disabled.                                     |
 //! | `#[redact(with = 'X')]`        |   | Specifies the `char` the string will be redacted with.                                                                                                                               |   | `'*'`                                         |
 //! | `#[redact(fixed = <integer>)]` |   | If this modifier is present, the length and contents of<br>the string are completely ignored and the string will always<br>be redacted as a fixed number of redaction characters.    |   | Disabled.                                     |
 //! | `#[redact(display)]`           |   | Overrides the redaction behavior to use the type's [`Display`](std::fmt::Display) implementation instead of [`Debug`].                                                               |   | Disabled.                                     |
@@ -40,7 +41,7 @@
 //! ```rust
 //! # use veil_macros::Redact;
 //! #[derive(Redact)]
-//! #[redact(all, partial, with = 'X')]
+//! #[redact(all, partial, with = 'X', all_utf8)]
 //! struct Foo {
 //!     redact_me: String,
 //!     also_redact_me: String,
@@ -56,10 +57,10 @@
 //! # use veil_macros::Redact;
 //! #[derive(Redact)]
 //! struct Foo {
-//!     #[redact(partial, with = 'X')]
+//!     #[redact(partial, with = 'X', all_utf8)]
 //!     redact_me: String,
 //!
-//!     #[redact(partial, with = 'X')]
+//!     #[redact(partial, with = 'X', all_utf8)]
 //!     also_redact_me: String,
 //!
 //!     do_not_redact_me: String,

--- a/src/private.rs
+++ b/src/private.rs
@@ -35,6 +35,9 @@ pub enum RedactionLength {
 
 #[derive(Clone, Copy)]
 pub struct RedactFlags {
+    /// If we should skip non-alphanumeric characters when redacting
+    pub skip_non_alphanumeric: bool,
+
     /// How much of the data to redact.
     pub redact_length: RedactionLength,
 
@@ -54,7 +57,7 @@ impl RedactFlags {
         let count = to_redact.chars().filter(|char| char.is_alphanumeric()).count();
         if count < Self::MIN_PARTIAL_CHARS {
             for char in to_redact.chars() {
-                if char.is_alphanumeric() {
+                if char.is_alphanumeric() && self.skip_non_alphanumeric {
                     fmt.write_char(self.redact_char)?;
                 } else {
                     fmt.write_char(char)?;
@@ -87,7 +90,7 @@ impl RedactFlags {
 
     pub(crate) fn redact_full(&self, fmt: &mut std::fmt::Formatter, to_redact: &str) -> std::fmt::Result {
         for char in to_redact.chars() {
-            if char.is_whitespace() || !char.is_alphanumeric() {
+            if (char.is_whitespace() || !char.is_alphanumeric()) && self.skip_non_alphanumeric {
                 fmt.write_char(char)?;
             } else {
                 fmt.write_char(self.redact_char)?;

--- a/veil-macros/src/flags.rs
+++ b/veil-macros/src/flags.rs
@@ -105,12 +105,15 @@ pub struct RedactFlags {
 
     /// The character to use for redacting. Defaults to `*`.
     pub redact_char: char,
+
+    pub all_utf8: bool,
 }
 impl Default for RedactFlags {
     fn default() -> Self {
         Self {
             redact_length: RedactionLength::Full,
             redact_char: '*',
+            all_utf8: false,
         }
     }
 }
@@ -138,6 +141,8 @@ impl ExtractFlags for RedactFlags {
                 NonZeroU8::new(int)
                     .ok_or_else(|| syn::Error::new_spanned(int, "fixed redacting width must be greater than zero"))
             })?)
+        } else if meta.path.is_ident("all_utf8") {
+            self.all_utf8 = true;
         } else {
             return Ok(ParseMeta::Unrecognised);
         }
@@ -149,12 +154,14 @@ impl quote::ToTokens for RedactFlags {
         let Self {
             redact_length,
             redact_char,
+            all_utf8,
             ..
         } = self;
 
         tokens.extend(quote! {
             redact_length: #redact_length,
-            redact_char: #redact_char
+            redact_char: #redact_char,
+            skip_non_alphanumeric: !#all_utf8,
         });
     }
 }


### PR DESCRIPTION
I implemented an option to redact all data to prevent partial (or complete) leaks of sensitive data. 

I left the default behavior as it was before, but in my opinion the default should really be complete redaction and users can opt in to risk partially (or completely) leaking data.

Resolves: https://github.com/primait/veil/issues/179