### PR TITLE
style: remove explicit call to `.into_iter()`

### DIFF
--- a/veil-macros/src/enums.rs
+++ b/veil-macros/src/enums.rs
@@ -163,7 +163,7 @@ pub(super) fn derive_redact(
     // Create an iterator that will yield the tokens of the body of the match arm for each variant.
     // These match arm bodies will actually print data into the Formatter.
     let mut variant_bodies = Vec::with_capacity(e.variants.len());
-    for (variant, flags) in e.variants.iter().zip(variant_flags.into_iter()) {
+    for (variant, flags) in e.variants.iter().zip(variant_flags) {
         // Variant name redacting
         let variant_name = variant.ident.to_string();
         let variant_name = if let Some(flags @ FieldFlags { skip: false, .. }) = &flags.variant_flags {


### PR DESCRIPTION
clippy is failing in ci https://github.com/primait/veil/actions/runs/26266016316/job/77309301873?pr=314